### PR TITLE
Clear "remote:" even where an output line is shorter than it

### DIFF
--- a/gitreceived.go
+++ b/gitreceived.go
@@ -24,7 +24,7 @@ import (
 
 const PrereceiveHookTmpl = `#!/bin/bash
 set -eo pipefail; while read oldrev newrev refname; do
-[[ $refname = "refs/heads/master" ]] && git archive $newrev | {{RECEIVER}} "$RECEIVE_REPO" "$newrev" | sed -$([[ $(uname) == "Darwin" ]] && echo l || echo u) "s/^/"$'\e[1G'"/"
+[[ $refname = "refs/heads/master" ]] && git archive $newrev | {{RECEIVER}} "$RECEIVE_REPO" "$newrev" | sed -$([[ $(uname) == "Darwin" ]] && echo l || echo u) "s/^/"$'\e[1G\e[K'"/"
 done
 `
 


### PR DESCRIPTION
In ANSI escape code, the EL code (`CSI n K`) is defined as below:

```
CSI n K : EL – Erase in Line

Erases part of the line. If n is zero (or missing), clear from cursor to the end of the line.
If n is one, clear from cursor to beginning of the line.
If n is two, clear entire line. Cursor position does not change.
```

Here is an examples of `CSI n G` and `CSI n K`.

```
$ echo 'remote: \e[1Gtest'
testte:

$ echo 'remote: \e[1G\e[Ktest'
test
```

Signed-off-by: Ryo Nakamura r7kamura@gmail.com
